### PR TITLE
Sign as each DLEQ key as a proof of knowledge

### DIFF
--- a/src/coins/meros/transaction.rs
+++ b/src/coins/meros/transaction.rs
@@ -121,7 +121,7 @@ impl Send {
   pub fn sign(&mut self, key: <Ed25519Sha as CryptEngine>::PrivateKey) {
     let mut to_sign = b"MEROS".to_vec();
     to_sign.extend(&self.hash);
-    self.signature = Some(Ed25519Sha::signature_to_bytes(&Ed25519Sha::sign(&key, &to_sign)));
+    self.signature = Some(Ed25519Sha::signature_to_bytes(&Ed25519Sha::sign(&key, &to_sign).unwrap()));
   }
 
   pub fn mine(&mut self, diff: u32) {

--- a/src/coins/nano/engine.rs
+++ b/src/coins/nano/engine.rs
@@ -147,7 +147,7 @@ impl NanoEngine {
 
   fn complete_block(inner: BlockInner, key: <Ed25519Blake2b as CryptEngine>::PrivateKey, work_threshold: u64) -> Block {
     let hash = inner.get_hash();
-    let signature = Ed25519Blake2b::sign(&key, &hash.0);
+    let signature = Ed25519Blake2b::sign(&key, &hash.0).unwrap();
     let work = Self::compute_work(inner.root_bytes().clone(), work_threshold);
     Block {
       inner,

--- a/src/crypt_engines/mod.rs
+++ b/src/crypt_engines/mod.rs
@@ -31,7 +31,7 @@ pub struct Commitment<Engine: CryptEngine> {
 pub trait CryptEngine: Sized {
   type PrivateKey: PartialEq + Serialize + DeserializeOwned + Clone + Sized + Send + Sync + 'static;
   type PublicKey: PartialEq + Serialize + DeserializeOwned + Clone + Sized + Send + Sync + 'static;
-  type Signature: PartialEq + Clone + Sized + Send + Sync + 'static;
+  type Signature: PartialEq + Serialize + DeserializeOwned + Clone + Sized + Send + Sync + 'static;
   type EncryptedSignature: PartialEq + Clone + Sized + Send + Sync + 'static;
 
   fn new_private_key() -> Self::PrivateKey;
@@ -56,6 +56,9 @@ pub trait CryptEngine: Sized {
   fn public_key_to_bytes(key: &Self::PublicKey) -> Vec<u8>;
   fn signature_to_bytes(sig: &Self::Signature) -> Vec<u8>;
   fn encrypted_signature_to_bytes(sig: &Self::EncryptedSignature) -> Vec<u8>;
+
+  fn sign(secret_key: &Self::PrivateKey, message: &[u8]) -> anyhow::Result<Self::Signature>;
+  fn verify_signature(public_key: &Self::PublicKey, message: &[u8], signature: &Self::Signature) -> anyhow::Result<()>;
 
   fn encrypted_sign(
     signing_key: &Self::PrivateKey,


### PR DESCRIPTION
Contrary to the implication of the xmr-btc paper, the MRL-0010 dleq proof doesn't suffice as a proof of knowledge of the keys (which is probably more of a problem with MRL-0010 itself).